### PR TITLE
Fix `on_application_command_error`

### DIFF
--- a/bot/cogs/backend/error_handler.py
+++ b/bot/cogs/backend/error_handler.py
@@ -114,6 +114,8 @@ class ErrorHandler(Cog):
         if isinstance(e, errors.CommandOnCooldown):
             log.debug(debug_message)
             await ctx.respond(e)
+        else:
+            log.error(e)
 
     async def handle_user_input_error(
         self, ctx: Context, e: errors.UserInputError


### PR DESCRIPTION
Previously didn't do anything if the error was not `errors.CommandOnCooldown`