### PR TITLE
Fix Update Trophies Task + updateandshowtrophies command

### DIFF
--- a/bot/resources/json/trophy_tracking.json
+++ b/bot/resources/json/trophy_tracking.json
@@ -8,27 +8,27 @@
         {
             "username": "SKORPID_TM",
             "player_id": "6a7a889f-cbff-4910-b369-a4201de53cb8",
-            "score": 17645138
+            "score": 17646138
         },
         {
             "username": "marshalbains",
             "player_id": "0d555703-96cc-4d9e-9e19-84b63f6171d3",
-            "score": 10591429
+            "score": 10529797
         },
         {
             "username": "dOgA_TM",
             "player_id": "6b319aed-690e-4d5a-bcf2-d73b057c9315",
-            "score": 6878828
+            "score": 7011678
         },
         {
             "username": "kunal1398",
             "player_id": "48e8de52-2473-4a1d-b095-190a79af5085",
-            "score": 5455437
+            "score": 5651446
         },
         {
             "username": "IridiuM_",
             "player_id": "20acef53-a982-4bc3-989f-399e03c70f4d",
-            "score": 5270853
+            "score": 5259640
         },
         {
             "username": "OjasTM",
@@ -38,27 +38,27 @@
         {
             "username": "rehan-TM",
             "player_id": "1bd22a9f-9301-4299-a7e1-6b787d3308af",
-            "score": 4328423
+            "score": 4327423
         },
         {
             "username": "NottCurious",
             "player_id": "b73fe3d7-a92a-4a6d-ab9d-49005caec499",
-            "score": 4105419
+            "score": 4183995
         },
         {
             "username": "AlbatrxssX",
             "player_id": "e32028c9-f65c-4dfc-b64a-df8b68650efd",
-            "score": 3330075
+            "score": 3263944
         },
         {
             "username": "Lost_Sole",
             "player_id": "db89905d-8265-467c-9dc4-721b5cd864d7",
-            "score": 2852858
+            "score": 2858945
         },
         {
             "username": "Divyansh_TM",
             "player_id": "d661b420-fd70-4fac-b7fd-2b1e03e98d12",
-            "score": 2362819
+            "score": 2484273
         },
         {
             "username": "Ein_Kartoffel",
@@ -68,7 +68,7 @@
         {
             "username": "ich_bin_kk",
             "player_id": "fc0666f5-60a2-4a3d-a24e-9269e75e487c",
-            "score": 1598228
+            "score": 1609064
         },
         {
             "username": "InFocus.TM",
@@ -78,12 +78,12 @@
         {
             "username": "hachikuku",
             "player_id": "4be8d8fc-3c47-4f41-8e5e-1370092c263f",
-            "score": 1196165
+            "score": 1196887
         },
         {
             "username": "DarKPhoeniXGOD",
             "player_id": "c067fae1-f274-42b3-a849-629878f0b36f",
-            "score": 1124106
+            "score": 1123101
         },
         {
             "username": "Kaizer_TM",
@@ -103,7 +103,7 @@
         {
             "username": "Mesh.TM",
             "player_id": "19dc96e5-363c-4ae8-8da0-7d0620566929",
-            "score": 537012
+            "score": 541347
         },
         {
             "username": "ChiefGupta",


### PR DESCRIPTION
Fix the update trophies task by forcing the bot to fetch the channel instead of only getting it.
Create a new command to force update and show the trophy leaderboards.